### PR TITLE
Enforce admin privilege for /ibash dynamic module

### DIFF
--- a/src/command_modules/ibash.cpp
+++ b/src/command_modules/ibash.cpp
@@ -342,7 +342,7 @@ DECLARE_COMMAND_HANDLER(ibash) {
 }  // namespace
 
 extern "C" DYN_COMMAND_EXPORT const struct DynModule DYN_COMMAND_SYM = {
-    .flags = DynModule::Flags::None,
+    .flags = DynModule::Flags::Enforced,
     .name = "ibash",
     .description = "Interactive bash shell",
     .function = COMMAND_HANDLER_NAME(ibash),


### PR DESCRIPTION
### Motivation
- The `/ibash` command was exported with `DynModule::Flags::None` in `src/command_modules/ibash.cpp`, which allowed non-admin, non-blacklisted users to run shell commands as the bot; the change restores the intended privileged access.

### Description
- Replace `.flags = DynModule::Flags::None` with `.flags = DynModule::Flags::Enforced` in `src/command_modules/ibash.cpp` so the module is registered as a privileged/admin command while preserving existing behavior for authorized users.

### Testing
- Verified the edit with `git diff -- src/command_modules/ibash.cpp`, inspected the modified file with `nl`, checked repository status with `git status --short`, and committed the change; no full build/test was performed due to external dependency fetch restrictions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a79b94dd08330a7bccedc63625a52)