### PR TITLE
Harden kernel builder config-name path handling

### DIFF
--- a/src/api/builtin_modules/builder/builder-rs/src/kernelbuild/build_service.rs
+++ b/src/api/builtin_modules/builder/builder-rs/src/kernelbuild/build_service.rs
@@ -86,6 +86,31 @@ type WrappedBuildStatus = Arc<Mutex<Vec<PerBuildIdStatus>>>;
 type WrappedContexts = Arc<Mutex<Vec<BuildContext>>>;
 
 impl BuildService {
+    fn validate_config_name(name: &str) -> Result<(), Status> {
+        if name.is_empty() {
+            return Err(Status::invalid_argument("Config name cannot be empty"));
+        }
+
+        let path = Path::new(name);
+        if path.is_absolute() {
+            return Err(Status::invalid_argument(
+                "Config name must be a relative path component",
+            ));
+        }
+
+        if path.components().count() != 1 || path.parent().is_some() {
+            return Err(Status::invalid_argument(
+                "Config name must be a single path component",
+            ));
+        }
+
+        if name == "." || name == ".." {
+            return Err(Status::invalid_argument("Config name is not allowed"));
+        }
+
+        Ok(())
+    }
+
     pub fn new(
         kernel_configs: Vec<KernelConfig>,
         builder_config: BuilderConfig,
@@ -539,6 +564,7 @@ impl linux_kernel_build_service_server::LinuxKernelBuildService for BuildService
             Ok(v) => v,
             Err(e) => return Err(Status::invalid_argument(format!("Bad JSON: {}", e))),
         };
+        Self::validate_config_name(&json_val.name)?;
 
         // 2. Store the valid config in memory
         let mut configs = self.kernel_configs.lock().await;
@@ -562,6 +588,7 @@ impl linux_kernel_build_service_server::LinuxKernelBuildService for BuildService
             Ok(v) => v,
             Err(e) => return Err(Status::invalid_argument(format!("Bad JSON: {}", e))),
         };
+        Self::validate_config_name(&json_val.name)?;
 
         // 2. Update existing config in memory
         let mut configs = self.kernel_configs.lock().await;


### PR DESCRIPTION
### Motivation
- Prevent untrusted `KernelConfig.name` values from escaping the builder output directory and enabling deletion/replacement of arbitrary Git worktrees via the reclone logic.

### Description
- Add `BuildService::validate_config_name` to enforce that config names are non-empty, not absolute, not `.`/`..`, and a single path component. 
- Call `validate_config_name` from both `add_config` and `update_config` before storing or updating in-memory `KernelConfig` entries in `src/api/builtin_modules/builder/builder-rs/src/kernelbuild/build_service.rs`.
- This fixes the ingestion point so later filesystem operations derive paths only from validated single-component names and mitigates the remove-and-reclone abuse described in the report.

### Testing
- Ran `cargo check` in `src/api/builtin_modules/builder/builder-rs`, which could not complete due to network restrictions fetching the crates.io index (HTTP 403 CONNECT tunnel failure).
- No unit tests were added or executed because the build environment prevented completing dependency resolution; the change is intentionally minimal and localized to input validation to minimize functional impact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a792bd88c83308fd5555c5e822b8d)