### PR TITLE
Fix file transfer stream lifetime race

### DIFF
--- a/src/api/net/SocketServiceImpl.cpp
+++ b/src/api/net/SocketServiceImpl.cpp
@@ -474,7 +474,8 @@ Status SocketServiceImpl::Service::downloadFileLoop(
     LogWhoCalledMe(context, "downloadFileLoop");
 
     while (stream->Read(&msg)) {
-        std::fstream* fileStream = nullptr;
+        std::vector<char> buffer(CHUNK_SIZE);
+        std::streamsize bytesRead = 0;
         {
             std::lock_guard<std::mutex> lock(activeTransfersMutex_);
             auto it = activeTransfers_.find(msg.uuid());
@@ -488,24 +489,23 @@ Status SocketServiceImpl::Service::downloadFileLoop(
                 stream->Write(response);
                 return Status::OK;
             }
-            fileStream = &it->second.fileStream;
-        }
 
-        // Perform I/O without holding the lock
-        fileStream->seekg(msg.chunk_idx() * CHUNK_SIZE, std::ios::beg);
-        if (!fileStream->good()) {
-            // Seek failed
-            FileChunkResponse response;
-            response.set_success(false);
-            response.set_retry(true);
-            LOG(ERROR) << "Seek failed during file download: " << msg.uuid();
-            stream->Write(response);
-            return Status::OK;
-        }
+            it->second.fileStream.seekg(msg.chunk_idx() * CHUNK_SIZE,
+                                        std::ios::beg);
+            if (!it->second.fileStream.good()) {
+                // Seek failed
+                FileChunkResponse response;
+                response.set_success(false);
+                response.set_retry(true);
+                LOG(ERROR) << "Seek failed during file download: "
+                           << msg.uuid();
+                stream->Write(response);
+                return Status::OK;
+            }
 
-        std::vector<char> buffer(CHUNK_SIZE);
-        fileStream->read(buffer.data(), buffer.size());
-        std::streamsize bytesRead = fileStream->gcount();
+            it->second.fileStream.read(buffer.data(), buffer.size());
+            bytesRead = it->second.fileStream.gcount();
+        }
 
         if (bytesRead <= 0) {
             // Read failed
@@ -540,7 +540,6 @@ Status SocketServiceImpl::Service::uploadFileLoop(
 
     LogWhoCalledMe(context, "uploadFileLoop");
     while (stream->Read(&msg)) {
-        std::fstream* fileStream = nullptr;
         {
             std::lock_guard<std::mutex> lock(activeTransfersMutex_);
             auto it = activeTransfers_.find(msg.uuid());
@@ -554,7 +553,6 @@ Status SocketServiceImpl::Service::uploadFileLoop(
                 stream->Write(response);
                 return Status::OK;
             }
-            fileStream = &it->second.fileStream;
             if (msg.chunk_offset() < 0 ||
                 static_cast<std::uintmax_t>(msg.chunk_offset()) +
                         msg.chunk_data().size() >
@@ -567,28 +565,30 @@ Status SocketServiceImpl::Service::uploadFileLoop(
                 stream->Write(response);
                 return Status::OK;
             }
-        }
 
-        // Perform I/O without holding the lock
-        fileStream->seekp(msg.chunk_offset(), std::ios::beg);
-        if (!fileStream->good()) {
-            // Seek failed
-            FileChunkResponse response;
-            response.set_success(false);
-            response.set_retry(true);
-            LOG(ERROR) << "Seek failed during file upload: " << msg.uuid();
-            stream->Write(response);
-            return Status::OK;
-        }
-        fileStream->write(msg.chunk_data().data(), msg.chunk_data().size());
-        if (!fileStream->good()) {
-            // Write failed
-            FileChunkResponse response;
-            response.set_success(false);
-            response.set_retry(true);
-            LOG(ERROR) << "Write failed during file upload: " << msg.uuid();
-            stream->Write(response);
-            return Status::OK;
+            it->second.fileStream.seekp(msg.chunk_offset(), std::ios::beg);
+            if (!it->second.fileStream.good()) {
+                // Seek failed
+                FileChunkResponse response;
+                response.set_success(false);
+                response.set_retry(true);
+                LOG(ERROR) << "Seek failed during file upload: "
+                           << msg.uuid();
+                stream->Write(response);
+                return Status::OK;
+            }
+            it->second.fileStream.write(msg.chunk_data().data(),
+                                        msg.chunk_data().size());
+            if (!it->second.fileStream.good()) {
+                // Write failed
+                FileChunkResponse response;
+                response.set_success(false);
+                response.set_retry(true);
+                LOG(ERROR) << "Write failed during file upload: "
+                           << msg.uuid();
+                stream->Write(response);
+                return Status::OK;
+            }
         }
         // Send success response
         FileChunkResponse response;


### PR DESCRIPTION
### Motivation
- The file transfer loops captured raw pointers to `std::fstream` objects owned by `activeTransfers_` and then performed I/O after releasing `activeTransfersMutex_`, introducing a race where `endFileTransfer` can erase the map entry and destroy the stream, causing a use-after-free and potential crash or memory corruption. 
- The change restores safe ownership/lifetime semantics for map-owned streams so an attacker who can reach the socket service cannot reliably trigger a remote crash/denial-of-service via a race. 

### Description
- `downloadFileLoop` was modified to stop capturing a raw `std::fstream*` and instead perform `seekg`/`read` and `gcount()` on `it->second.fileStream` while holding `activeTransfersMutex_`. 
- `uploadFileLoop` was modified to perform `seekp`/`write` on `it->second.fileStream` inside the mutex scope and to remove the previously unlocked raw-pointer usage. 
- Existing request validation, error responses, and chunk-response behavior are preserved, and buffer/`bytesRead` are declared before the locked region to keep the I/O behavior unchanged. 

### Testing
- Attempted to run a local build with `cmake --build build`, but the `build/` directory is not present in this environment so the build could not be executed. 
- No automated unit tests were executed in this environment after the change due to the missing build artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a7988c968833088c7f9619ec46ad6)