### PR TITLE
Fix RBE token shell injection in generated env script

### DIFF
--- a/src/api/builtin_modules/builder/builder-rs/src/rombuild/build_service.rs
+++ b/src/api/builtin_modules/builder/builder-rs/src/rombuild/build_service.rs
@@ -164,7 +164,7 @@ export NINJA_REMOTE_NUM_JOBS=128
 
 # --- BuildBuddy Connection Settings ---
 export RBE_service="aosp.buildbuddy.io:443"
-export RBE_remote_headers="x-buildbuddy-api-key={}"
+export RBE_remote_headers={}
 export RBE_use_rpc_credentials=false
 export RBE_service_no_auth=true
 
@@ -206,8 +206,8 @@ export RBE_LINT=1
 export RBE_JAVA_POOL=default
 export RBE_METALAVA_POOL=default
 export RBE_LINT_POOL=default"##,
-            rbe_cli_path.to_string_lossy().to_string(),
-            rbe_api_token
+            Self::shell_single_quote(&rbe_cli_path.to_string_lossy()),
+            Self::shell_single_quote(&format!("x-buildbuddy-api-key={}", rbe_api_token))
         );
         std::fs::write(&rbe_env_path, content)
             .map_err(|e| Status::internal(format!("Failed to write RBE env file: {}", e)))?;


### PR DESCRIPTION
### Motivation
- A caller-controlled `rbe_api_token` was being embedded inside a double-quoted shell assignment in `rbe_env.sh` and later `source`d by the build shell, enabling command injection when `use_rbe_service` is enabled.
- The intent of this change is to neutralize that shell execution sink while preserving the existing behavior of writing and sourcing the RBE environment file.

### Description
- Modified `src/api/builtin_modules/builder/builder-rs/src/rombuild/build_service.rs` to emit `RBE_remote_headers` as a shell-quoted literal instead of a double-quoted interpolated string.
- Reused the existing helper `shell_single_quote` to produce a safe single-quoted shell literal for both the `rbe_cli` path and the `x-buildbuddy-api-key=<token>` value written into the generated file via `setup_rbe_env`.
- The change preserves writing `rbe_env.sh` and subsequent `source` behavior but prevents shell evaluation of attacker-controlled token content.

### Testing
- Attempted to run `cargo check --manifest-path src/api/builtin_modules/builder/builder-rs/Cargo.toml`, but dependency resolution failed due to network access to `crates.io` being blocked (HTTP 403), so the check could not complete.
- No other automated tests were executed in this environment due to the network restrictions described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a7b62eb6c83308435ef1f95a0bfb9)