### PR TITLE
fix(kernelbuild): sanitize kernel artifact filename before filesystem writes

### DIFF
--- a/src/api/builtin_modules/builder/kernel/kernelbuild.cpp
+++ b/src/api/builtin_modules/builder/kernel/kernelbuild.cpp
@@ -526,7 +526,9 @@ bool KernelBuildHandler::handle_artifact_download(
     artifactRequest.set_build_id(build_id);
     ArtifactMetadata artifactMetadata;
     std::ofstream outputFile;
+    std::filesystem::path localArtifactPath;
     bool fileOpenError = false;
+    bool invalidFilename = false;
 
     bool success = buildService->getArtifact(
         artifactRequest, [&](const ArtifactChunk& chunk) {
@@ -538,10 +540,24 @@ bool KernelBuildHandler::handle_artifact_download(
                 LOG(INFO) << "Receiving artifact: "
                           << artifactMetadata.filename()
                           << ", size: " << artifactMetadata.total_size();
-                outputFile.open(artifactMetadata.filename(), std::ios::binary);
+                const auto safeFilename =
+                    std::filesystem::path(artifactMetadata.filename())
+                        .filename();
+                if (safeFilename.empty() || safeFilename == "." ||
+                    safeFilename == "..") {
+                    LOG(ERROR) << "Invalid artifact filename from build "
+                                  "service: "
+                               << artifactMetadata.filename();
+                    invalidFilename = true;
+                    return;
+                }
+                localArtifactPath = std::filesystem::temp_directory_path() /
+                                    fmt::format("kernelbuild_{}_{}", build_id,
+                                                safeFilename.string());
+                outputFile.open(localArtifactPath, std::ios::binary);
                 if (!outputFile.is_open()) {
                     LOG(ERROR) << "Failed to open output file: "
-                               << artifactMetadata.filename();
+                               << localArtifactPath.string();
                     fileOpenError = true;
                     return;
                 }
@@ -549,6 +565,11 @@ bool KernelBuildHandler::handle_artifact_download(
             outputFile.write(chunk.data().data(), chunk.data().size());
         });
     outputFile.close();
+
+    if (invalidFilename) {
+        editQueryMessage(query, "Build service returned an invalid artifact name.");
+        return false;
+    }
 
     if (fileOpenError) {
         editQueryMessage(query, "Failed to open output file for writing.");
@@ -565,7 +586,7 @@ bool KernelBuildHandler::handle_artifact_download(
 
     LOG(INFO) << "Artifact " << artifactMetadata.filename()
               << " received successfully.";
-    *outPath = artifactMetadata.filename();
+    *outPath = localArtifactPath;
     return true;
 }
 


### PR DESCRIPTION
### Motivation
- The kernel build client previously used the service-supplied `ArtifactMetadata.filename` directly as a local filesystem path, allowing absolute paths, path traversal, or colliding filenames to be written and later removed by the bot process.
- The change confines artifact writes/deletes to a controlled local path and rejects invalid filenames to mitigate an attacker-controlled or MITM build service producing dangerous paths.

### Description
- Updated `handle_artifact_download` in `src/api/builtin_modules/builder/kernel/kernelbuild.cpp` to extract only the basename from `artifactMetadata.filename()` via `std::filesystem::path(...).filename()` and to reject empty, `.` or `..` basenames.
- Writes the artifact into a controlled location under `std::filesystem::temp_directory_path()` with a build-id-prefixed name instead of opening the remote-provided path directly, and returns that `localArtifactPath` through `outPath` for downstream send/delete.
- Produces an error message and aborts download if the filename is invalid or if opening the controlled local file fails, preserving the existing artifact download/send/delete flow otherwise.

### Testing
- Ran static repository checks (diff-check) and repository status inspection which succeeded after the change.
- Verified the modified `handle_artifact_download` compiles locally up to the repository checks performed in this environment; full project build was not completed here due to missing packaging/config files for `fmt` in the container.
- No unit/integration tests were available or executed in this environment, so runtime validation and CI builds should be run to confirm behavior in target environments.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a8486b654833097c1c00f21e68f8a)