### PR TITLE
Fix sparse-file DoS risk in upload finalization

### DIFF
--- a/src/api/net/SocketServiceImpl.cpp
+++ b/src/api/net/SocketServiceImpl.cpp
@@ -628,15 +628,14 @@ Status SocketServiceImpl::Service::endFileTransfer(
             activeTransfers_.erase(it);
             return Status::OK;
         }
-        // Move temporary file to final destination
+        // Move temporary file to final destination using rename to avoid
+        // materializing sparse holes during a copy.
         try {
-            const auto options =
-                entry.overwriteExisting
-                    ? std::filesystem::copy_options::overwrite_existing
-                    : std::filesystem::copy_options::none;
-            std::filesystem::copy_file(entry.filePath, request->file_path(),
-                                       options);
-            std::filesystem::remove(entry.filePath);
+            std::error_code moveEc;
+            if (entry.overwriteExisting) {
+                std::filesystem::remove(request->file_path(), moveEc);
+            }
+            std::filesystem::rename(entry.filePath, request->file_path());
             LOG(INFO) << "File uploaded successfully to: "
                       << request->file_path();
         } catch (const std::filesystem::filesystem_error& e) {


### PR DESCRIPTION
### Motivation
- The previous upload finalization used `std::filesystem::copy_file(...)`, which can materialize sparse holes from an attacker-shaped temporary upload into a fully-allocated destination and lead to disk/I/O exhaustion.
- The upload loop already validates chunk ranges, but the copy step reintroduces amplification by copying sparse files, so finalization must avoid copy-time materialization.
- Use a metadata-only move to preserve sparseness and maintain the intended transfer semantics without adding heavy I/O.

### Description
- Replaced the `std::filesystem::copy_file(entry.filePath, request->file_path(), ...)` + `remove` sequence with a conditional destination `remove` when `overwrite_existing` is requested followed by `std::filesystem::rename(entry.filePath, request->file_path())` in `endFileTransfer` in `src/api/net/SocketServiceImpl.cpp`.
- Added a comment explaining the change to avoid materializing sparse holes and used an `std::error_code` for the destination `remove` to ignore benign failures before `rename`.
- Preserved existing checksum verification and temporary file cleanup behavior on error paths.

### Testing
- Confirmed the upload code path bounds-checks chunk ranges in `uploadFileLoop` via source inspection, mitigating out-of-range writes at upload time. 
- Attempted to run the build configuration with `cmake -S . -B build`, but the configure step failed due to an unrelated network/fetch error for the `fmt` dependency (`CONNECT tunnel failed, response 403`), so no full build or runtime tests were executed in this environment. 
- No automated unit tests were added or run as part of this change; the change is intentionally minimal to preserve existing behavior while preventing copy-time materialization.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a86985e88833086fd45aea7e4ed0e)