### PR TITLE
Require AdminUser authorization for kernelbuild callback handlers

### DIFF
--- a/src/api/builtin_modules/builder/kernel/kernelbuild.cpp
+++ b/src/api/builtin_modules/builder/kernel/kernelbuild.cpp
@@ -357,7 +357,8 @@ class KernelBuildHandler {
     void handleCallbackQuery(const TgBot::CallbackQuery::Ptr& query) {
         std::string_view data = query->data;
 
-        if (!_auth->isAuthorized(query->from)) {
+        if (!_auth->isAuthorized(query->from,
+                                 AuthContext::AccessLevel::AdminUser)) {
             _api->answerCallbackQuery(
                 query->id,
                 "Sorry son, you are not allowed to touch this keyboard.");
@@ -632,7 +633,8 @@ DECLARE_COMMAND_HANDLER(kernelbuild) {
                 [api, provider](const TgBot::CallbackQuery::Ptr& ptr) {
                     std::string_view data = ptr->data;
 
-                    if (!provider->auth->isAuthorized(ptr->from)) {
+                    if (!provider->auth->isAuthorized(
+                            ptr->from, AuthContext::AccessLevel::AdminUser)) {
                         api->answerCallbackQuery(
                             ptr->id,
                             "Sorry son, you are not allowed to touch this "


### PR DESCRIPTION
### Motivation
- Close an authorization bypass where kernelbuild callback flows (including single-device/no-fragment shortcuts) could reach privileged build execution while using the default `Unprotected` check, allowing non-admin users to trigger builds.

### Description
- Require `AuthContext::AccessLevel::AdminUser` for callback gating in `KernelBuildHandler::handleCallbackQuery` in `src/api/builtin_modules/builder/kernel/kernelbuild.cpp` so the handler only accepts admin-authorized users.
- Require `AuthContext::AccessLevel::AdminUser` in the outer `api->onCallbackQuery("kernelbuild", ...)` wrapper in the same file to ensure the callback is rejected early for non-admin users.
- This is a minimal targeted change that preserves existing build flow/auto-skip logic but enforces the intended admin-only access level for the module.

### Testing
- Verified the modified file shows explicit `AdminUser` checks at both callback entry points in `src/api/builtin_modules/builder/kernel/kernelbuild.cpp` by inspecting the local diff and file contents.
- Ran repository searches/inspections to confirm the callback paths now use `isAuthorized(..., AuthContext::AccessLevel::AdminUser)`; no other functional tests were executed in this environment due to missing build dependency `fmt` which prevents a full build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a8bedffb8833086045b240ebc46d8)