### PR TITLE
fix(auth): require AdminUser for privileged builder callbacks

### DIFF
--- a/src/api/builtin_modules/builder/android/romBuild.cpp
+++ b/src/api/builtin_modules/builder/android/romBuild.cpp
@@ -1302,7 +1302,7 @@ void ROMBuildQueryHandler::onCallbackQuery(
         DLOG(INFO) << "Mismatch on message id";
         return;
     }
-    if (!_auth->isAuthorized(query->from)) {
+    if (!_auth->isAuthorized(query->from, AuthContext::AccessLevel::AdminUser)) {
         _api->answerCallbackQuery(
             query->id,
             "Sorry son, you are not allowed to touch this keyboard.");

--- a/src/api/builtin_modules/builder/kernel/kernelbuild.cpp
+++ b/src/api/builtin_modules/builder/kernel/kernelbuild.cpp
@@ -357,7 +357,7 @@ class KernelBuildHandler {
     void handleCallbackQuery(const TgBot::CallbackQuery::Ptr& query) {
         std::string_view data = query->data;
 
-        if (!_auth->isAuthorized(query->from)) {
+        if (!_auth->isAuthorized(query->from, AuthContext::AccessLevel::AdminUser)) {
             _api->answerCallbackQuery(
                 query->id,
                 "Sorry son, you are not allowed to touch this keyboard.");
@@ -632,7 +632,8 @@ DECLARE_COMMAND_HANDLER(kernelbuild) {
                 [api, provider](const TgBot::CallbackQuery::Ptr& ptr) {
                     std::string_view data = ptr->data;
 
-                    if (!provider->auth->isAuthorized(ptr->from)) {
+                    if (!provider->auth->isAuthorized(ptr->from,
+                                                AuthContext::AccessLevel::AdminUser)) {
                         api->answerCallbackQuery(
                             ptr->id,
                             "Sorry son, you are not allowed to touch this "


### PR DESCRIPTION
### Motivation
- Fix a privilege-escalation regression introduced by the `AuthContext` refactor where no-argument `isAuthorized()` calls defaulted to `AccessLevel::Unprotected`, allowing non-admin users to interact with privileged inline-builder keyboards.

### Description
- Require explicit admin access by passing `AuthContext::AccessLevel::AdminUser` to the ROM builder callback gate in `ROMBuildQueryHandler::onCallbackQuery`.
- Require explicit admin access by passing `AuthContext::AccessLevel::AdminUser` to the kernel builder `handleCallbackQuery` gate and to the top-level `api->onCallbackQuery` registration guard in the kernel module.
- This change is intentionally minimal and scoped only to the identified privileged callback entry points and does not alter other modules or command registration semantics.

### Testing
- Verified with `rg` that the builder callback entry points now call `isAuthorized(..., AuthContext::AccessLevel::AdminUser)` and no longer rely on the default-argument path.
- Confirmed the working tree was updated and contains only the intended changes to the two builder source files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a9212ec6c8330b2ce2ade55e5e7ea)