### PR TITLE
Fix upload finalization path clobber when overwrite is disabled

### DIFF
--- a/src/api/net/SocketServiceImpl.cpp
+++ b/src/api/net/SocketServiceImpl.cpp
@@ -111,6 +111,7 @@ class SocketServiceImpl::Service : public SocketService::Service {
     struct TranferEntry {
         std::fstream fileStream;
         std::filesystem::path filePath;
+        std::filesystem::path destinationPath;
         std::uintmax_t totalSize = 0;
         int chunk_count{};
         ChecksumAlgorithm checksumAlgorithm = ChecksumAlgorithm::None;
@@ -410,6 +411,7 @@ Status SocketServiceImpl::Service::requestFileTransfer(
             entry.checksum = request->file_checksum();
         }
         entry.overwriteExisting = request->overwrite_existing();
+        entry.destinationPath = request->file_path();
 
         // For upload, we create a temporary file to store incoming data
         entry.filePath = std::filesystem::temp_directory_path() /
@@ -618,6 +620,18 @@ Status SocketServiceImpl::Service::endFileTransfer(
     TranferEntry& entry = it->second;
     entry.fileStream.close();
     if (request->is_upload()) {
+        if (request->file_path() != entry.destinationPath) {
+            response->set_code(GenericResponseCode::ErrorInvalidArgument);
+            response->set_message(
+                "Upload destination path mismatch for this transfer");
+            LOG(ERROR) << "Upload destination path mismatch for UUID "
+                       << request->uuid() << ": expected "
+                       << entry.destinationPath.string() << ", got "
+                       << request->file_path();
+            std::filesystem::remove(entry.filePath);
+            activeTransfers_.erase(it);
+            return Status::OK;
+        }
         if (entry.checksumAlgorithm != ChecksumAlgorithm::None &&
             !verify_file_checksum(entry.filePath, entry.checksumAlgorithm,
                                   entry.checksum)) {
@@ -633,11 +647,11 @@ Status SocketServiceImpl::Service::endFileTransfer(
         try {
             std::error_code moveEc;
             if (entry.overwriteExisting) {
-                std::filesystem::remove(request->file_path(), moveEc);
+                std::filesystem::remove(entry.destinationPath, moveEc);
             }
-            std::filesystem::rename(entry.filePath, request->file_path());
+            std::filesystem::rename(entry.filePath, entry.destinationPath);
             LOG(INFO) << "File uploaded successfully to: "
-                      << request->file_path();
+                      << entry.destinationPath.string();
         } catch (const std::filesystem::filesystem_error& e) {
             response->set_code(GenericResponseCode::ErrorCommandIgnored);
             response->set_message(


### PR DESCRIPTION
### Motivation
- The upload finalize logic used `std::filesystem::rename` against the `file_path` provided at finalize time, which allowed replacing an existing file even when `overwrite_existing` was false. 
- The intent is to enforce the protocol's default no-overwrite semantics while preserving rename-based finalization to avoid copying sparse files.

### Description
- Add `destinationPath` to `TranferEntry` and capture the requested upload destination in `requestFileTransfer` by setting `entry.destinationPath = request->file_path()`. 
- In `endFileTransfer`, verify that the finalize request's `file_path` matches the stored `entry.destinationPath` and reject the finalize if they differ, cleaning up the temporary file and transfer state. 
- Use `entry.destinationPath` for the remove/rename operations so the stored, validated destination is the only allowed finalize target and only remove the destination when `overwriteExisting` is true.

### Testing
- Verified the code delta with `git diff -- src/api/net/SocketServiceImpl.cpp` which shows the intended changes and `git status --short` which reported a clean working tree. 
- Committed the change successfully as `Fix upload finalize path to enforce no-overwrite semantics`. 
- Attempted an automated build with `cmake -S . -B build-debug-validate -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS='-O0 -g'`, but the build could not complete due to missing dependency `fmt` and a `FetchContent` network clone returning HTTP 403, so no compile or unit tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b03fbbed48330828018fe798a5d55)