### PR TITLE
Fix build workflow failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -250,6 +250,10 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy,rustfmt
+      - name: Install protoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
         with:
@@ -274,5 +278,5 @@ jobs:
         run: |
           python3 -m compileall -q resources/scripts
           find resources/scripts -type f -name '*.sh' -print0 | xargs -0 -r -n1 bash -n
-          python3 -c 'import json,pathlib; [json.loads(p.read_text()) for p in pathlib.Path(".").rglob("*.json") if "src/third-party" not in p.as_posix() and "vcpkg_installed" not in p.as_posix()]'
+          python3 -c 'import json,pathlib; [json.loads(p.read_text(encoding="utf-8")) for p in pathlib.Path(".").rglob("*.json") if "src/third-party" not in p.as_posix() and "vcpkg_installed" not in p.as_posix()]'
           python3 -c 'import pathlib,sys; suffixes={".c",".cc",".cpp",".h",".hpp"}; bad=[str(p) for p in pathlib.Path("src").rglob("*") if p.suffix in suffixes and "third-party" not in p.parts and b"\0" in p.read_bytes()]; print("Embedded NUL byte found in: " + ", ".join(bad), file=sys.stderr) if bad else None; sys.exit(bool(bad))'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,6 +196,13 @@ jobs:
             FEATURES="image-opencv;image;database;luamodules;testing;backtrace;web"
           fi
 
+          # Cross compilers come from the chainloaded target toolchain. Do not
+          # leak them into vcpkg's native host-tool builds (x64-linux), where
+          # they would be combined with host flags such as -m64.
+          if [ "${{ matrix.cross }}" = "true" ]; then
+            unset CC CXX
+          fi
+
           cmake -B build -S . \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_TOOLCHAIN_FILE="$VCPKG_PATH" \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,9 @@ jobs:
             cc: GCC-ARMHF
             real_cc: arm-linux-gnueabihf-gcc
             real_cxx: arm-linux-gnueabihf-g++
-            flags: '-DVCPKG_TARGET_TRIPLET=arm-linux-release -DVCPKG_INSTALL_OPTIONS=--allow-unsupported -DVCPKG_OVERLAY_TRIPLETS=${{ github.workspace }}/CMake/triplets -DVCPKG_CHAINLOAD_TOOLCHAIN_FILE=${{ github.workspace }}/CMake/toolchains/toolchain-armhf.cmake'
+            # Matrix strings are not recursively expression-expanded. Use the
+            # runner's shell variable so these paths do not collapse to /CMake.
+            flags: '-DVCPKG_TARGET_TRIPLET=arm-linux-release -DVCPKG_INSTALL_OPTIONS=--allow-unsupported -DVCPKG_OVERLAY_TRIPLETS=$GITHUB_WORKSPACE/CMake/triplets -DVCPKG_CHAINLOAD_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/CMake/toolchains/toolchain-armhf.cmake'
             features: 'image;database;luamodules;backtrace;web'
             build_tests: 'OFF'
             cross: true

--- a/CMake/toolchains/toolchain-armhf.cmake
+++ b/CMake/toolchains/toolchain-armhf.cmake
@@ -4,6 +4,15 @@ set(CMAKE_SYSTEM_PROCESSOR arm)
 set(CMAKE_C_COMPILER arm-linux-gnueabihf-gcc)
 set(CMAKE_CXX_COMPILER arm-linux-gnueabihf-g++)
 
+# This file is chainloaded by vcpkg, so the triplet's VCPKG_C_FLAGS and
+# VCPKG_CXX_FLAGS are intentionally not applied. Define the target flags here
+# for C, C++, and assembler sources. The explicit FPU is required when ports
+# such as Crypto++ add a bare -march=armv7-a to individual assembly files.
+set(_TGBOTCPP_ARMHF_FLAGS "-march=armv7-a -mfpu=neon -mfloat-abi=hard")
+string(APPEND CMAKE_C_FLAGS_INIT " ${_TGBOTCPP_ARMHF_FLAGS}")
+string(APPEND CMAKE_CXX_FLAGS_INIT " ${_TGBOTCPP_ARMHF_FLAGS}")
+string(APPEND CMAKE_ASM_FLAGS_INIT " ${_TGBOTCPP_ARMHF_FLAGS}")
+
 # The all-important sandbox rules
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)

--- a/CMake/toolchains/toolchain-armhf.cmake
+++ b/CMake/toolchains/toolchain-armhf.cmake
@@ -6,9 +6,11 @@ set(CMAKE_CXX_COMPILER arm-linux-gnueabihf-g++)
 
 # This file is chainloaded by vcpkg, so the triplet's VCPKG_C_FLAGS and
 # VCPKG_CXX_FLAGS are intentionally not applied. Define the target flags here
-# for C, C++, and assembler sources. The explicit FPU is required when ports
-# such as Crypto++ add a bare -march=armv7-a to individual assembly files.
-set(_TGBOTCPP_ARMHF_FLAGS "-march=armv7-a -mfpu=neon -mfloat-abi=hard")
+# for C, C++, and assembler sources. Keep vcpkg Linux's normal -fPIC because
+# static dependencies are linked into Glider's shared command modules. The
+# explicit FPU is required when ports such as Crypto++ add a bare
+# -march=armv7-a to individual assembly files.
+set(_TGBOTCPP_ARMHF_FLAGS "-fPIC -march=armv7-a -mfpu=neon -mfloat-abi=hard")
 string(APPEND CMAKE_C_FLAGS_INIT " ${_TGBOTCPP_ARMHF_FLAGS}")
 string(APPEND CMAKE_CXX_FLAGS_INIT " ${_TGBOTCPP_ARMHF_FLAGS}")
 string(APPEND CMAKE_ASM_FLAGS_INIT " ${_TGBOTCPP_ARMHF_FLAGS}")

--- a/CMake/triplets/arm-linux-release.cmake
+++ b/CMake/triplets/arm-linux-release.cmake
@@ -10,8 +10,9 @@ set(VCPKG_BUILD_TYPE release)
 # Crypto++'s cryptogams *_armv4.S assembly) override the arch with a bare
 # -march=armv7-a, which drops the FPU and makes the hard-float ABI fail with
 # "selected architecture lacks an FPU". Pin an explicit NEON FPU so an FPU is
-# always available regardless of per-source -march overrides. (The .S files are
-# driven through the C compiler, so VCPKG_C_FLAGS is what actually fixes them.)
+# always available regardless of per-source -march overrides. Crypto++ enables
+# ASM as a separate CMake language, so pass the flag through both vcpkg's C/C++
+# settings and CMAKE_ASM_FLAGS.
 set(VCPKG_C_FLAGS "-mfpu=neon")
 set(VCPKG_CXX_FLAGS "-mfpu=neon")
-set(VCPKG_ASM_FLAGS "-mfpu=neon")
+set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_ASM_FLAGS=-mfpu=neon")

--- a/CMake/triplets/arm-linux-release.cmake
+++ b/CMake/triplets/arm-linux-release.cmake
@@ -4,6 +4,10 @@ set(VCPKG_LIBRARY_LINKAGE static)
 
 set(VCPKG_CMAKE_SYSTEM_NAME Linux)
 set(VCPKG_BUILD_TYPE release)
+set(
+    VCPKG_CHAINLOAD_TOOLCHAIN_FILE
+    "${CMAKE_CURRENT_LIST_DIR}/../toolchains/toolchain-armhf.cmake"
+)
 
-# Compiler flags live in the chainloaded toolchain. vcpkg deliberately does
-# not apply VCPKG_C_FLAGS or VCPKG_CXX_FLAGS when a chainload toolchain is set.
+# Compiler flags live in the chainloaded toolchain above. vcpkg deliberately
+# does not apply VCPKG_C_FLAGS or VCPKG_CXX_FLAGS when one is set.

--- a/CMake/triplets/arm-linux-release.cmake
+++ b/CMake/triplets/arm-linux-release.cmake
@@ -5,14 +5,5 @@ set(VCPKG_LIBRARY_LINKAGE static)
 set(VCPKG_CMAKE_SYSTEM_NAME Linux)
 set(VCPKG_BUILD_TYPE release)
 
-# The arm-linux-gnueabihf toolchain defaults to the hard-float ABI, whose
-# default -march (armv7-a+fp) already provides an FPU. Some ports (e.g.
-# Crypto++'s cryptogams *_armv4.S assembly) override the arch with a bare
-# -march=armv7-a, which drops the FPU and makes the hard-float ABI fail with
-# "selected architecture lacks an FPU". Pin an explicit NEON FPU so an FPU is
-# always available regardless of per-source -march overrides. Crypto++ enables
-# ASM as a separate CMake language, so pass the flag through both vcpkg's C/C++
-# settings and CMAKE_ASM_FLAGS.
-set(VCPKG_C_FLAGS "-mfpu=neon")
-set(VCPKG_CXX_FLAGS "-mfpu=neon")
-set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_ASM_FLAGS=-mfpu=neon")
+# Compiler flags live in the chainloaded toolchain. vcpkg deliberately does
+# not apply VCPKG_C_FLAGS or VCPKG_CXX_FLAGS when a chainload toolchain is set.

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "version": 3,
   "configurePresets": [
     {

--- a/src/api/builtin_modules/builder/builder-rs/src/git_repo.rs
+++ b/src/api/builtin_modules/builder/builder-rs/src/git_repo.rs
@@ -289,7 +289,7 @@ impl GitRepo {
         let branch_ref = self
             .repo
             .find_branch(&branch, git2::BranchType::Remote)
-            .warn_err_string(format!("Cannot find remote branch {} by name", &branch))?;
+            .warn_err_string(format!("Cannot find remote branch {} by name", branch))?;
         let branch_commit = branch_ref.get().peel_to_commit()?;
 
         info!(

--- a/src/api/builtin_modules/builder/builder-rs/src/kernelbuild/builder_config.rs
+++ b/src/api/builtin_modules/builder/builder-rs/src/kernelbuild/builder_config.rs
@@ -231,7 +231,7 @@ impl Toolchain {
             }
             Source::Tarball => {
                 info!("Downloading toolchain {} from {}", self.name, self.url);
-                let dest_file = dest_path.join(format!("{}.tar.gz", &self.name));
+                let dest_file = dest_path.join(format!("{}.tar.gz", self.name));
                 Self::download_file(&self.url, &dest_file, async |_current, total| {
                     info!(
                         "Downloading toolchain... Total downloaded {} KB",

--- a/src/api/builtin_modules/builder/builder-rs/src/kernelbuild/grpc.rs
+++ b/src/api/builtin_modules/builder/builder-rs/src/kernelbuild/grpc.rs
@@ -638,7 +638,7 @@ impl linux_kernel_build_service_server::LinuxKernelBuildService for BuildService
             }
 
             debug!("Running make defconfig in directory: {:?}", &source_dir);
-            let log_file = tmp_dir.join(format!("output-prepare-{}.log", &config.name));
+            let log_file = tmp_dir.join(format!("output-prepare-{}.log", config.name));
             info!("Defconfig log file will be at: {:?}", &log_file);
             let success = run_process(
                 runner.as_ref(),
@@ -819,7 +819,7 @@ impl linux_kernel_build_service_server::LinuxKernelBuildService for BuildService
                 info!("Setting environment variable for make: {}={}", name, value);
                 proc.env(name.clone(), value.clone());
             }
-            let log_file = tmp_dir.join(format!("output-build-{}.log", &context.config.name));
+            let log_file = tmp_dir.join(format!("output-build-{}.log", context.config.name));
             info!("Build log file will be at: {:?}", &log_file);
             debug!("Running make in directory: {:?}", &context.work_dir);
 

--- a/src/api/builtin_modules/builder/builder-rs/src/rombuild/harness.rs
+++ b/src/api/builtin_modules/builder/builder-rs/src/rombuild/harness.rs
@@ -208,7 +208,7 @@ impl RomBuildHarness {
         }
 
         let res = async {
-                let build_log_filename_suffix = format!("build-{}.log", &build_id_clone);
+                let build_log_filename_suffix = format!("build-{}.log", build_id_clone);
                 // First, check if repo command is available
                 if build_settings.do_repo_sync {
                     send_log!(LogLevel::Debug, "Checking for 'repo' command availability...".to_string());
@@ -284,7 +284,7 @@ impl RomBuildHarness {
                             .await
                             .map_err(|e| BuildError::internal(format!("Failed to send to stdin: {}", e)))?;
 
-                        let error_file = tempdir_clone.join(format!("{}-{}", "repo-init", &build_log_filename_suffix));
+                        let error_file = tempdir_clone.join(format!("{}-{}", "repo-init", build_log_filename_suffix));
                         info!("Repo init output log path: {:?}", &error_file);
 
                         let res = run_process(
@@ -364,7 +364,7 @@ impl RomBuildHarness {
                                             repo.checkout_branch(&branch_entry.name).map_err(|e| {
                                                 BuildError::internal(format!(
                                                     "Failed to checkout branch {} of local manifest repository: {}",
-                                                    &branch_entry.name, e
+                                                    branch_entry.name, e
                                                 ))
                                             })?;
                                         } else {
@@ -454,7 +454,7 @@ impl RomBuildHarness {
                                                             &build_dir_clone,
                                                             askpass_path_clone.as_deref(),
                                                         );
-                                                        let error_file = tempdir_clone.join(format!("{}-{}-submodule-sync.log", "repo-sync", &build_id_clone));
+                                                        let error_file = tempdir_clone.join(format!("{}-{}-submodule-sync.log", "repo-sync", build_id_clone));
                                                         info!("Repo sync for submodule output log path: {:?}", &error_file);
                                                         let repo_sync_status = run_process(
                                                             runner.as_ref(),
@@ -622,7 +622,7 @@ impl RomBuildHarness {
                         &build_dir_clone,
                         askpass_path_clone.as_deref(),
                     );
-                    let error_file = tempdir_clone.join(format!("{}-{}", "repo-sync", &build_log_filename_suffix));
+                    let error_file = tempdir_clone.join(format!("{}-{}", "repo-sync", build_log_filename_suffix));
                     info!("Repo sync output log path: {:?}", &error_file);
 
                     let repo_sync_status = run_process(
@@ -905,7 +905,7 @@ impl RomBuildHarness {
                     send_log!(LogLevel::Info, format!("Sent to stdin: {}", line));
                 }
 
-                let error_file_path = tempdir_clone.join(format!("{}-{}", "build-output", &build_log_filename_suffix));
+                let error_file_path = tempdir_clone.join(format!("{}-{}", "build-output", build_log_filename_suffix));
                 if !run_process(
                     runner.as_ref(),
                     cmd,

--- a/src/command_modules/support/popen_wdt/popen_wdt_posix.c
+++ b/src/command_modules/support/popen_wdt/popen_wdt_posix.c
@@ -35,6 +35,7 @@ struct popen_wdt_posix_priv {
     int status;
     int pipefd_r;  // Subprocess' readfd, write end for the child
     _Atomic bool process_is_running;
+    bool watchdog_thread_joined;
 };
 
 // Helper to add seconds to timespec safely
@@ -262,6 +263,7 @@ static void popen_watchdog_wait(popen_watchdog_data_t** data_in) {
         pthread_cond_signal(&pdata->condition);
         POPEN_WDT_DBGLOG("Waiting for watchdog");
         pthread_join(pdata->wdt_thread, NULL);
+        pdata->watchdog_thread_joined = true;
         POPEN_WDT_DBGLOG("watchdog joined");
     }
 }
@@ -285,9 +287,10 @@ popen_watchdog_exit_t popen_watchdog_destroy(popen_watchdog_data_t** data_in) {
     pthread_cond_signal(&pdata->condition);
     pthread_mutex_unlock(&pdata->wdt_mutex);
 
-    if (data->watchdog_enabled) {
+    if (data->watchdog_enabled && !pdata->watchdog_thread_joined) {
         POPEN_WDT_DBGLOG("Waiting for watchdog thread to finish");
         pthread_join(pdata->wdt_thread, NULL);
+        pdata->watchdog_thread_joined = true;
         POPEN_WDT_DBGLOG("Watchdog thread finished");
     }
 

--- a/tests/DatabaseBackendsTest.cpp
+++ b/tests/DatabaseBackendsTest.cpp
@@ -135,7 +135,8 @@ TEST(SQLiteDatabaseTest, RejectsUnsupportedFutureSchemaVersion) {
                       "glider-sqlite-future-schema-test.db";
     std::filesystem::remove(path);
     sqlite3* raw = nullptr;
-    ASSERT_EQ(sqlite3_open(path.c_str(), &raw), SQLITE_OK);
+    const auto pathString = path.string();
+    ASSERT_EQ(sqlite3_open(pathString.c_str(), &raw), SQLITE_OK);
     ASSERT_EQ(sqlite3_exec(raw, "PRAGMA user_version=999", nullptr, nullptr,
                            nullptr),
               SQLITE_OK);


### PR DESCRIPTION
## Summary

Fix the failures reported by the Build Glider (Multi-Platform) workflow across iterative diagnostic runs:

- remove the UTF-8 BOM from `CMakePresets.json` and make JSON decoding explicit in source hygiene
- install `protobuf-compiler` for the Rust quality job
- prevent `popen_watchdog_destroy()` from joining an already-joined watchdog thread
- make the ARMHF matrix paths shell-expand correctly
- chainload the ARM cross-toolchain from the vcpkg triplet and apply ARMv7 hard-float/FPU flags to C, C++, and ASM
- isolate the ARM target compiler from native x64 host-tool builds
- retain `-fPIC` for ARMHF static dependencies linked into shared command modules
- convert the filesystem path to a narrow string before calling `sqlite3_open()` on Windows
- fix Rust 1.97 `useless_borrows_in_formatting` Clippy errors

## Root causes

The runs exposed independent platform and tooling issues:

- BOM-sensitive JSON parsing and a missing standalone `protoc` dependency
- a second `pthread_join()` detected by ASan/TSan
- Windows `filesystem::path::c_str()` returning a wide string for an API requiring `const char *`
- GitHub expressions embedded in a matrix string collapsing ARM paths to `/CMake/...`
- the outer CMake chainload setting not propagating to vcpkg dependency builds; vcpkg ports obtain it from the triplet
- global `CC`/`CXX` values leaking the ARM cross-compiler into native `x64-linux` host dependencies, producing `arm-linux-gnueabihf-gcc -m64`
- replacing vcpkg's default Linux toolchain also dropped its normal `-fPIC`; non-PIC static Abseil objects then failed to link into command-module shared libraries with `R_ARM_TLS_LE32` relocations
- new Rust 1.97 Clippy lints promoted to errors by `-D warnings`

## Validation

- `git diff --check`
- source-hygiene Python, shell, JSON, embedded-NUL, and BOM checks
- reviewed each edit against the exact GitHub Actions compiler, sanitizer, or linker diagnostic
- run #151 passed source validation, CodeQL, Rust formatting/tests/Clippy, and every build matrix job except ARMHF
- ARMHF run #151 configured all 75 vcpkg dependencies successfully and reached 86% of the project build before exposing the missing-PIC link failure

A new Actions run is validating the restored ARMHF PIC flags. The PR remains draft until the workflow is green.